### PR TITLE
fix 'melt_data()' helper function to correctly filter out all columns…

### DIFF
--- a/time-series/starter_notebook.ipynb
+++ b/time-series/starter_notebook.ipynb
@@ -76,22 +76,15 @@
    "outputs": [],
    "source": [
     "def get_datetimes(df):\n",
+    "    \"\"\"\n",
+    "    Takes a dataframe:\n",
+    "    returns only those column names that can be converted into datetime objects \n",
+    "    as datetime objects.\n",
+    "    NOTE number of returned columns may not match total number of columns in passed dataframe\n",
+    "    \"\"\"\n",
+    "    \n",
     "    return pd.to_datetime(df.columns.values[1:], format='%Y-%m')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -171,7 +164,16 @@
    "outputs": [],
    "source": [
     "def melt_data(df):\n",
-    "    melted = pd.melt(df, id_vars=['RegionName', 'City', 'State', 'Metro', 'CountyName'], var_name='time')\n",
+    "    \"\"\"\n",
+    "    Takes the zillow_data dataset in wide form or a subset of the zillow_dataset.  \n",
+    "    Returns a long-form datetime dataframe \n",
+    "    with the datetime column names as the index and the values as the 'values' column.\n",
+    "    \n",
+    "    If more than one row is passes in the wide-form dataset, the values column\n",
+    "    will be the mean of the values from the datetime columns in all of the rows.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    melted = pd.melt(df, id_vars=['RegionName', 'RegionID', 'SizeRank', 'City', 'State', 'Metro', 'CountyName'], var_name='time')\n",
     "    melted['time'] = pd.to_datetime(melted['time'], infer_datetime_format=True)\n",
     "    melted = melted.dropna(subset=['value'])\n",
     "    return melted.groupby('time').aggregate({'value':'mean'})"
@@ -179,16 +181,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex([], dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": []
   },
   {
@@ -299,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
melt_data() function was not correctly removing RegionID and SizeRank when converting df from wide to long format.  I added those two columns to the list of id_vars= columns.  I also created doc strings get_datetime() and melt_data() functions.